### PR TITLE
add web view controller w/ pushState/popState bridge API

### DIFF
--- a/BridgeOfDeathTest/BridgeOfDeathTest.xcodeproj/project.pbxproj
+++ b/BridgeOfDeathTest/BridgeOfDeathTest.xcodeproj/project.pbxproj
@@ -1,0 +1,478 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		17BB08A91AE6D99000B0FBDA /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17BB08A81AE6D99000B0FBDA /* AppDelegate.swift */; };
+		17BB08AB1AE6D99000B0FBDA /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17BB08AA1AE6D99000B0FBDA /* ViewController.swift */; };
+		17BB08AE1AE6D99000B0FBDA /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 17BB08AC1AE6D99000B0FBDA /* Main.storyboard */; };
+		17BB08B01AE6D99000B0FBDA /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 17BB08AF1AE6D99000B0FBDA /* Images.xcassets */; };
+		17BB08B31AE6D99000B0FBDA /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 17BB08B11AE6D99000B0FBDA /* LaunchScreen.xib */; };
+		17BB08BF1AE6D99000B0FBDA /* BridgeOfDeathTestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17BB08BE1AE6D99000B0FBDA /* BridgeOfDeathTestTests.swift */; };
+		17BB08E11AE6DA2300B0FBDA /* THGBridge.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 17BB08DE1AE6DA0A00B0FBDA /* THGBridge.framework */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		17BB08B91AE6D99000B0FBDA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 17BB089B1AE6D99000B0FBDA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 17BB08A21AE6D99000B0FBDA;
+			remoteInfo = BridgeOfDeathTest;
+		};
+		17BB08DD1AE6DA0A00B0FBDA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 17BB08D61AE6DA0A00B0FBDA /* THGBridge.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = CAC38A9D1AC3130B005A3CE0;
+			remoteInfo = THGBridge;
+		};
+		17BB08DF1AE6DA0A00B0FBDA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 17BB08D61AE6DA0A00B0FBDA /* THGBridge.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = CAC38AA81AC3130B005A3CE0;
+			remoteInfo = THGBridgeTests;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		17BB08A31AE6D99000B0FBDA /* BridgeOfDeathTest.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BridgeOfDeathTest.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		17BB08A71AE6D99000B0FBDA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		17BB08A81AE6D99000B0FBDA /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		17BB08AA1AE6D99000B0FBDA /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		17BB08AD1AE6D99000B0FBDA /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		17BB08AF1AE6D99000B0FBDA /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
+		17BB08B21AE6D99000B0FBDA /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
+		17BB08B81AE6D99000B0FBDA /* BridgeOfDeathTestTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BridgeOfDeathTestTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		17BB08BD1AE6D99000B0FBDA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		17BB08BE1AE6D99000B0FBDA /* BridgeOfDeathTestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgeOfDeathTestTests.swift; sourceTree = "<group>"; };
+		17BB08D61AE6DA0A00B0FBDA /* THGBridge.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = THGBridge.xcodeproj; path = ../THGBridge.xcodeproj; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		17BB08A01AE6D99000B0FBDA /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				17BB08E11AE6DA2300B0FBDA /* THGBridge.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		17BB08B51AE6D99000B0FBDA /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		17BB089A1AE6D99000B0FBDA = {
+			isa = PBXGroup;
+			children = (
+				17BB08D61AE6DA0A00B0FBDA /* THGBridge.xcodeproj */,
+				17BB08A51AE6D99000B0FBDA /* BridgeOfDeathTest */,
+				17BB08BB1AE6D99000B0FBDA /* BridgeOfDeathTestTests */,
+				17BB08A41AE6D99000B0FBDA /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		17BB08A41AE6D99000B0FBDA /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				17BB08A31AE6D99000B0FBDA /* BridgeOfDeathTest.app */,
+				17BB08B81AE6D99000B0FBDA /* BridgeOfDeathTestTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		17BB08A51AE6D99000B0FBDA /* BridgeOfDeathTest */ = {
+			isa = PBXGroup;
+			children = (
+				17BB08A81AE6D99000B0FBDA /* AppDelegate.swift */,
+				17BB08AA1AE6D99000B0FBDA /* ViewController.swift */,
+				17BB08AC1AE6D99000B0FBDA /* Main.storyboard */,
+				17BB08AF1AE6D99000B0FBDA /* Images.xcassets */,
+				17BB08B11AE6D99000B0FBDA /* LaunchScreen.xib */,
+				17BB08A61AE6D99000B0FBDA /* Supporting Files */,
+			);
+			path = BridgeOfDeathTest;
+			sourceTree = "<group>";
+		};
+		17BB08A61AE6D99000B0FBDA /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				17BB08A71AE6D99000B0FBDA /* Info.plist */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		17BB08BB1AE6D99000B0FBDA /* BridgeOfDeathTestTests */ = {
+			isa = PBXGroup;
+			children = (
+				17BB08BE1AE6D99000B0FBDA /* BridgeOfDeathTestTests.swift */,
+				17BB08BC1AE6D99000B0FBDA /* Supporting Files */,
+			);
+			path = BridgeOfDeathTestTests;
+			sourceTree = "<group>";
+		};
+		17BB08BC1AE6D99000B0FBDA /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				17BB08BD1AE6D99000B0FBDA /* Info.plist */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		17BB08D71AE6DA0A00B0FBDA /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				17BB08DE1AE6DA0A00B0FBDA /* THGBridge.framework */,
+				17BB08E01AE6DA0A00B0FBDA /* THGBridgeTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		17BB08A21AE6D99000B0FBDA /* BridgeOfDeathTest */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 17BB08C21AE6D99000B0FBDA /* Build configuration list for PBXNativeTarget "BridgeOfDeathTest" */;
+			buildPhases = (
+				17BB089F1AE6D99000B0FBDA /* Sources */,
+				17BB08A01AE6D99000B0FBDA /* Frameworks */,
+				17BB08A11AE6D99000B0FBDA /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = BridgeOfDeathTest;
+			productName = BridgeOfDeathTest;
+			productReference = 17BB08A31AE6D99000B0FBDA /* BridgeOfDeathTest.app */;
+			productType = "com.apple.product-type.application";
+		};
+		17BB08B71AE6D99000B0FBDA /* BridgeOfDeathTestTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 17BB08C51AE6D99000B0FBDA /* Build configuration list for PBXNativeTarget "BridgeOfDeathTestTests" */;
+			buildPhases = (
+				17BB08B41AE6D99000B0FBDA /* Sources */,
+				17BB08B51AE6D99000B0FBDA /* Frameworks */,
+				17BB08B61AE6D99000B0FBDA /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				17BB08BA1AE6D99000B0FBDA /* PBXTargetDependency */,
+			);
+			name = BridgeOfDeathTestTests;
+			productName = BridgeOfDeathTestTests;
+			productReference = 17BB08B81AE6D99000B0FBDA /* BridgeOfDeathTestTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		17BB089B1AE6D99000B0FBDA /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0630;
+				ORGANIZATIONNAME = TheHolyGrail;
+				TargetAttributes = {
+					17BB08A21AE6D99000B0FBDA = {
+						CreatedOnToolsVersion = 6.3;
+					};
+					17BB08B71AE6D99000B0FBDA = {
+						CreatedOnToolsVersion = 6.3;
+						TestTargetID = 17BB08A21AE6D99000B0FBDA;
+					};
+				};
+			};
+			buildConfigurationList = 17BB089E1AE6D99000B0FBDA /* Build configuration list for PBXProject "BridgeOfDeathTest" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 17BB089A1AE6D99000B0FBDA;
+			productRefGroup = 17BB08A41AE6D99000B0FBDA /* Products */;
+			projectDirPath = "";
+			projectReferences = (
+				{
+					ProductGroup = 17BB08D71AE6DA0A00B0FBDA /* Products */;
+					ProjectRef = 17BB08D61AE6DA0A00B0FBDA /* THGBridge.xcodeproj */;
+				},
+			);
+			projectRoot = "";
+			targets = (
+				17BB08A21AE6D99000B0FBDA /* BridgeOfDeathTest */,
+				17BB08B71AE6D99000B0FBDA /* BridgeOfDeathTestTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXReferenceProxy section */
+		17BB08DE1AE6DA0A00B0FBDA /* THGBridge.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = THGBridge.framework;
+			remoteRef = 17BB08DD1AE6DA0A00B0FBDA /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		17BB08E01AE6DA0A00B0FBDA /* THGBridgeTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = THGBridgeTests.xctest;
+			remoteRef = 17BB08DF1AE6DA0A00B0FBDA /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+/* End PBXReferenceProxy section */
+
+/* Begin PBXResourcesBuildPhase section */
+		17BB08A11AE6D99000B0FBDA /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				17BB08AE1AE6D99000B0FBDA /* Main.storyboard in Resources */,
+				17BB08B31AE6D99000B0FBDA /* LaunchScreen.xib in Resources */,
+				17BB08B01AE6D99000B0FBDA /* Images.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		17BB08B61AE6D99000B0FBDA /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		17BB089F1AE6D99000B0FBDA /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				17BB08AB1AE6D99000B0FBDA /* ViewController.swift in Sources */,
+				17BB08A91AE6D99000B0FBDA /* AppDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		17BB08B41AE6D99000B0FBDA /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				17BB08BF1AE6D99000B0FBDA /* BridgeOfDeathTestTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		17BB08BA1AE6D99000B0FBDA /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 17BB08A21AE6D99000B0FBDA /* BridgeOfDeathTest */;
+			targetProxy = 17BB08B91AE6D99000B0FBDA /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		17BB08AC1AE6D99000B0FBDA /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				17BB08AD1AE6D99000B0FBDA /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		17BB08B11AE6D99000B0FBDA /* LaunchScreen.xib */ = {
+			isa = PBXVariantGroup;
+			children = (
+				17BB08B21AE6D99000B0FBDA /* Base */,
+			);
+			name = LaunchScreen.xib;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		17BB08C01AE6D99000B0FBDA /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		17BB08C11AE6D99000B0FBDA /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		17BB08C31AE6D99000B0FBDA /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				INFOPLIST_FILE = BridgeOfDeathTest/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		17BB08C41AE6D99000B0FBDA /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				INFOPLIST_FILE = BridgeOfDeathTest/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+		17BB08C61AE6D99000B0FBDA /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+				);
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = BridgeOfDeathTestTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/BridgeOfDeathTest.app/BridgeOfDeathTest";
+			};
+			name = Debug;
+		};
+		17BB08C71AE6D99000B0FBDA /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = BridgeOfDeathTestTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/BridgeOfDeathTest.app/BridgeOfDeathTest";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		17BB089E1AE6D99000B0FBDA /* Build configuration list for PBXProject "BridgeOfDeathTest" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				17BB08C01AE6D99000B0FBDA /* Debug */,
+				17BB08C11AE6D99000B0FBDA /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		17BB08C21AE6D99000B0FBDA /* Build configuration list for PBXNativeTarget "BridgeOfDeathTest" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				17BB08C31AE6D99000B0FBDA /* Debug */,
+				17BB08C41AE6D99000B0FBDA /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		17BB08C51AE6D99000B0FBDA /* Build configuration list for PBXNativeTarget "BridgeOfDeathTestTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				17BB08C61AE6D99000B0FBDA /* Debug */,
+				17BB08C71AE6D99000B0FBDA /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 17BB089B1AE6D99000B0FBDA /* Project object */;
+}

--- a/BridgeOfDeathTest/BridgeOfDeathTest.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/BridgeOfDeathTest/BridgeOfDeathTest.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:BridgeOfDeathTest.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/BridgeOfDeathTest/BridgeOfDeathTest/AppDelegate.swift
+++ b/BridgeOfDeathTest/BridgeOfDeathTest/AppDelegate.swift
@@ -1,0 +1,46 @@
+//
+//  AppDelegate.swift
+//  BridgeOfDeathTest
+//
+//  Created by Angelo Di Paolo on 4/21/15.
+//  Copyright (c) 2015 TheHolyGrail. All rights reserved.
+//
+
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+    var window: UIWindow?
+
+
+    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+        // Override point for customization after application launch.
+        return true
+    }
+
+    func applicationWillResignActive(application: UIApplication) {
+        // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
+        // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
+    }
+
+    func applicationDidEnterBackground(application: UIApplication) {
+        // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
+        // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+    }
+
+    func applicationWillEnterForeground(application: UIApplication) {
+        // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
+    }
+
+    func applicationDidBecomeActive(application: UIApplication) {
+        // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+    }
+
+    func applicationWillTerminate(application: UIApplication) {
+        // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+    }
+
+
+}
+

--- a/BridgeOfDeathTest/BridgeOfDeathTest/Base.lproj/LaunchScreen.xib
+++ b/BridgeOfDeathTest/BridgeOfDeathTest/Base.lproj/LaunchScreen.xib
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6214" systemVersion="14A314h" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6207"/>
+        <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="480" height="480"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="  Copyright (c) 2015 TheHolyGrail. All rights reserved." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="8ie-xW-0ye">
+                    <rect key="frame" x="20" y="439" width="441" height="21"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="BridgeOfDeathTest" textAlignment="center" lineBreakMode="middleTruncation" baselineAdjustment="alignBaselines" minimumFontSize="18" translatesAutoresizingMaskIntoConstraints="NO" id="kId-c2-rCX">
+                    <rect key="frame" x="20" y="140" width="441" height="43"/>
+                    <fontDescription key="fontDescription" type="boldSystem" pointSize="36"/>
+                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+            </subviews>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+            <constraints>
+                <constraint firstItem="kId-c2-rCX" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="bottom" multiplier="1/3" constant="1" id="5cJ-9S-tgC"/>
+                <constraint firstAttribute="centerX" secondItem="kId-c2-rCX" secondAttribute="centerX" id="Koa-jz-hwk"/>
+                <constraint firstAttribute="bottom" secondItem="8ie-xW-0ye" secondAttribute="bottom" constant="20" id="Kzo-t9-V3l"/>
+                <constraint firstItem="8ie-xW-0ye" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="20" symbolic="YES" id="MfP-vx-nX0"/>
+                <constraint firstAttribute="centerX" secondItem="8ie-xW-0ye" secondAttribute="centerX" id="ZEH-qu-HZ9"/>
+                <constraint firstItem="kId-c2-rCX" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="20" symbolic="YES" id="fvb-Df-36g"/>
+            </constraints>
+            <nil key="simulatedStatusBarMetrics"/>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <point key="canvasLocation" x="548" y="455"/>
+        </view>
+    </objects>
+</document>

--- a/BridgeOfDeathTest/BridgeOfDeathTest/Base.lproj/Main.storyboard
+++ b/BridgeOfDeathTest/BridgeOfDeathTest/Base.lproj/Main.storyboard
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7531" systemVersion="14D131" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7520"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="BridgeOfDeathTest" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="y3c-jy-aDJ"/>
+                        <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Y34-nA-uIM">
+                                <rect key="frame" x="269" y="263" width="63" height="30"/>
+                                <state key="normal" title="WebView">
+                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <connections>
+                                    <action selector="openWebView:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Rqa-k7-cMC"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/BridgeOfDeathTest/BridgeOfDeathTest/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/BridgeOfDeathTest/BridgeOfDeathTest/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,68 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/BridgeOfDeathTest/BridgeOfDeathTest/Info.plist
+++ b/BridgeOfDeathTest/BridgeOfDeathTest/Info.plist
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>io.theholygrail.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/BridgeOfDeathTest/BridgeOfDeathTest/ViewController.swift
+++ b/BridgeOfDeathTest/BridgeOfDeathTest/ViewController.swift
@@ -24,7 +24,8 @@ class ViewController: UIViewController {
     @IBAction func openWebView(sender: UIButton) {
         let webController = WebViewController()
         let navController = UINavigationController(rootViewController: webController)
-        let url = NSURL(string: "http://www.techmeme.com/")!
+//        let url = NSURL(string: "http://localhost:3000/")!
+        let url = NSURL(string: "http://bridgeofdeath.herokuapp.com/")!
         
         webController.loadURL(url)
         presentViewController(navController, animated: true, completion: nil)

--- a/BridgeOfDeathTest/BridgeOfDeathTest/ViewController.swift
+++ b/BridgeOfDeathTest/BridgeOfDeathTest/ViewController.swift
@@ -1,0 +1,34 @@
+//
+//  ViewController.swift
+//  BridgeOfDeathTest
+//
+//  Created by Angelo Di Paolo on 4/21/15.
+//  Copyright (c) 2015 TheHolyGrail. All rights reserved.
+//
+
+import UIKit
+import THGBridge
+
+class ViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // Do any additional setup after loading the view, typically from a nib.
+    }
+
+    override func didReceiveMemoryWarning() {
+        super.didReceiveMemoryWarning()
+        // Dispose of any resources that can be recreated.
+    }
+
+    @IBAction func openWebView(sender: UIButton) {
+        let webController = WebViewController()
+        let navController = UINavigationController(rootViewController: webController)
+        let url = NSURL(string: "http://www.techmeme.com/")!
+        
+        webController.loadURL(url)
+        presentViewController(navController, animated: true, completion: nil)
+    }
+
+}
+

--- a/BridgeOfDeathTest/BridgeOfDeathTestTests/BridgeOfDeathTestTests.swift
+++ b/BridgeOfDeathTest/BridgeOfDeathTestTests/BridgeOfDeathTestTests.swift
@@ -1,0 +1,36 @@
+//
+//  BridgeOfDeathTestTests.swift
+//  BridgeOfDeathTestTests
+//
+//  Created by Angelo Di Paolo on 4/21/15.
+//  Copyright (c) 2015 TheHolyGrail. All rights reserved.
+//
+
+import UIKit
+import XCTest
+
+class BridgeOfDeathTestTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+    
+    func testExample() {
+        // This is an example of a functional test case.
+        XCTAssert(true, "Pass")
+    }
+    
+    func testPerformanceExample() {
+        // This is an example of a performance test case.
+        self.measureBlock() {
+            // Put the code you want to measure the time of here.
+        }
+    }
+    
+}

--- a/BridgeOfDeathTest/BridgeOfDeathTestTests/Info.plist
+++ b/BridgeOfDeathTest/BridgeOfDeathTestTests/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>io.theholygrail.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/README.md
+++ b/README.md
@@ -1,2 +1,38 @@
 # BridgeOfDeath
+
 THGBridge, a Javascript&lt;->Native bridge implementation in Swift
+
+
+## Usage
+
+### NativeBridge.navigation
+
+#### pushState()
+
+Trigger a native push navigation transition.
+
+**Parameters**
+
+**Example**
+
+```
+NativeBridge.navigation.pushState();
+
+```
+
+#### popState()
+
+Trigger a native pop navigation transition. Call after histor
+
+**Parameters**
+
+**Example**
+
+```
+NativeBridge.navigation.popState();
+
+```
+
+## Example
+
+A test iOS project is located in BridgeOfDeathTest/BridgeOfDeathTest.xcodeproj that is configured to load the test page at [http://bridgeofdeath.herokuapp.com/](http://bridgeofdeath.herokuapp.com/).

--- a/THGBridge.xcodeproj/project.pbxproj
+++ b/THGBridge.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1947E25A1AE04190004E189C /* WebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1947E2591AE04190004E189C /* WebViewController.swift */; };
 		CABA99911AC321B3008D25B4 /* THGFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CABA99811AC31D5D008D25B4 /* THGFoundation.framework */; };
 		CABA99921AC321B3008D25B4 /* THGLog.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CABA998A1AC32103008D25B4 /* THGLog.framework */; };
 		CAC38AA31AC3130B005A3CE0 /* THGBridge.h in Headers */ = {isa = PBXBuildFile; fileRef = CAC38AA21AC3130B005A3CE0 /* THGBridge.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -69,6 +70,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		1947E2591AE04190004E189C /* WebViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebViewController.swift; sourceTree = "<group>"; };
 		CABA997B1AC31D5D008D25B4 /* THGFoundation.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = THGFoundation.xcodeproj; path = ../Excalibur/THGFoundation.xcodeproj; sourceTree = "<group>"; };
 		CABA99841AC32103008D25B4 /* THGLog.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = THGLog.xcodeproj; path = ../Shrubbery/THGLog.xcodeproj; sourceTree = "<group>"; };
 		CAC38A9D1AC3130B005A3CE0 /* THGBridge.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = THGBridge.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -155,6 +157,7 @@
 			children = (
 				CAC38AA21AC3130B005A3CE0 /* THGBridge.h */,
 				CAC38AB91AC3136C005A3CE0 /* Bridge.swift */,
+				1947E2591AE04190004E189C /* WebViewController.swift */,
 				CAC38AA01AC3130B005A3CE0 /* Supporting Files */,
 			);
 			path = THGBridge;
@@ -336,6 +339,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CAC38ABA1AC3136C005A3CE0 /* Bridge.swift in Sources */,
+				1947E25A1AE04190004E189C /* WebViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/THGBridge.xcodeproj/project.pbxproj
+++ b/THGBridge.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1766B8931AE85EBA0039FFB5 /* BridgeNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1766B8921AE85EBA0039FFB5 /* BridgeNavigation.swift */; };
+		1766B8951AE85F650039FFB5 /* BridgePlatform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1766B8941AE85F650039FFB5 /* BridgePlatform.swift */; };
 		1947E25A1AE04190004E189C /* WebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1947E2591AE04190004E189C /* WebViewController.swift */; };
 		CABA99911AC321B3008D25B4 /* THGFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CABA99811AC31D5D008D25B4 /* THGFoundation.framework */; };
 		CABA99921AC321B3008D25B4 /* THGLog.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CABA998A1AC32103008D25B4 /* THGLog.framework */; };
@@ -70,6 +72,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		1766B8921AE85EBA0039FFB5 /* BridgeNavigation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BridgeNavigation.swift; sourceTree = "<group>"; };
+		1766B8941AE85F650039FFB5 /* BridgePlatform.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BridgePlatform.swift; sourceTree = "<group>"; };
 		1947E2591AE04190004E189C /* WebViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebViewController.swift; sourceTree = "<group>"; };
 		CABA997B1AC31D5D008D25B4 /* THGFoundation.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = THGFoundation.xcodeproj; path = ../Excalibur/THGFoundation.xcodeproj; sourceTree = "<group>"; };
 		CABA99841AC32103008D25B4 /* THGLog.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = THGLog.xcodeproj; path = ../Shrubbery/THGLog.xcodeproj; sourceTree = "<group>"; };
@@ -158,6 +162,8 @@
 				CAC38AA21AC3130B005A3CE0 /* THGBridge.h */,
 				CAC38AB91AC3136C005A3CE0 /* Bridge.swift */,
 				1947E2591AE04190004E189C /* WebViewController.swift */,
+				1766B8941AE85F650039FFB5 /* BridgePlatform.swift */,
+				1766B8921AE85EBA0039FFB5 /* BridgeNavigation.swift */,
 				CAC38AA01AC3130B005A3CE0 /* Supporting Files */,
 			);
 			path = THGBridge;
@@ -339,6 +345,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				CAC38ABA1AC3136C005A3CE0 /* Bridge.swift in Sources */,
+				1766B8951AE85F650039FFB5 /* BridgePlatform.swift in Sources */,
+				1766B8931AE85EBA0039FFB5 /* BridgeNavigation.swift in Sources */,
 				1947E25A1AE04190004E189C /* WebViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/THGBridge/Bridge.swift
+++ b/THGBridge/Bridge.swift
@@ -107,21 +107,37 @@ public class Bridge {
 
         downloadTask.resume()
     }
+}
 
-    // MARK: Exports API
-    
+// MARK: - Exports API
+
+extension Bridge {
+    /**
+    Add an exported object to the context
+    :param: export Object being exported to JavaScript
+    :param: name Name of object being exported
+    */
     public func addExport(export: JSExport, name: String) {
         exports[name] = export
         context.setObject(export, forKeyedSubscript: name)
     }
     
+    /**
+    Retrieve a JSValue out of the context by name.
+    :param: name Name of value to retrieve out of context.
+    */
     public func contextValueForName(name: String) -> JSValue {
         return context.objectForKeyedSubscript(name)
     }
 }
 
+// MARK: - Utilities
+
 extension UIWebView {
     
+    /**
+     Retreive the JavaScript context from the web view.
+    */
     public var javaScriptContext: JSContext? {
         return valueForKeyPath("documentView.webView.mainFrame.javaScriptContext") as? JSContext
     }

--- a/THGBridge/Bridge.swift
+++ b/THGBridge/Bridge.swift
@@ -120,3 +120,9 @@ public class Bridge {
     }
 }
 
+extension UIWebView {
+    
+    public var javaScriptContext: JSContext? {
+        return valueForKeyPath("documentView.webView.mainFrame.javaScriptContext") as? JSContext
+    }
+}

--- a/THGBridge/Bridge.swift
+++ b/THGBridge/Bridge.swift
@@ -38,6 +38,9 @@ public class Bridge {
     public var context: JSContext {
         didSet {
             for (name, script) in exports {
+                
+                println("add \(name) \(script)")
+                
                 context.setObject(script, forKeyedSubscript: name)
             }
             
@@ -131,14 +134,4 @@ extension Bridge {
     }
 }
 
-// MARK: - Utilities
 
-extension UIWebView {
-    
-    /**
-     Retreive the JavaScript context from the web view.
-    */
-    public var javaScriptContext: JSContext? {
-        return valueForKeyPath("documentView.webView.mainFrame.javaScriptContext") as? JSContext
-    }
-}

--- a/THGBridge/BridgeNavigation.swift
+++ b/THGBridge/BridgeNavigation.swift
@@ -1,0 +1,26 @@
+//
+//  BridgeNavigation.swift
+//  THGBridge
+//
+//  Created by Angelo Di Paolo on 4/22/15.
+//  Copyright (c) 2015 TheHolyGrail. All rights reserved.
+//
+
+import JavaScriptCore
+
+@objc protocol BridgeNavigationProtocol: JSExport {
+    func pushState()
+    func replaceState()
+}
+
+@objc class BridgeNavigation: NSObject, BridgeNavigationProtocol {
+    weak var webNavigator: WebViewControllerNavigator?
+    
+    func pushState() {
+        webNavigator?.pushState()
+    }
+    
+    func replaceState() {
+        webNavigator?.pushState()
+    }
+}

--- a/THGBridge/BridgeNavigation.swift
+++ b/THGBridge/BridgeNavigation.swift
@@ -10,6 +10,7 @@ import JavaScriptCore
 
 @objc protocol BridgeNavigationProtocol: JSExport {
     func pushState()
+    func popState()
     func replaceState()
 }
 
@@ -18,6 +19,10 @@ import JavaScriptCore
     
     func pushState() {
         webNavigator?.pushState()
+    }
+    
+    func popState() {
+        webNavigator?.popState()
     }
     
     func replaceState() {

--- a/THGBridge/BridgePlatform.swift
+++ b/THGBridge/BridgePlatform.swift
@@ -24,7 +24,7 @@ extension Bridge {
         return contextValueForName(bridgePlatformExportName).toObject() as? BridgePlatform
     }
     
-    func addPlatformIfNeeded() {
+    func addPlatformExportIfNeeded() {
         if platform == nil {
             let platform = BridgePlatform()
             platform.navigation = BridgeNavigation()

--- a/THGBridge/BridgePlatform.swift
+++ b/THGBridge/BridgePlatform.swift
@@ -1,0 +1,34 @@
+//
+//  BridgePlatform.swift
+//  THGBridge
+//
+//  Created by Angelo Di Paolo on 4/22/15.
+//  Copyright (c) 2015 TheHolyGrail. All rights reserved.
+//
+
+import JavaScriptCore
+
+@objc protocol BridgePlatformProtocol: JSExport {
+    var navigation: BridgeNavigation? {get}
+}
+
+@objc class BridgePlatform: NSObject, BridgePlatformProtocol {
+    var navigation: BridgeNavigation?
+}
+
+let bridgePlatformExportName = "NativeBridge"
+
+extension Bridge {
+    
+    var platform: BridgePlatform? {
+        return contextValueForName(bridgePlatformExportName).toObject() as? BridgePlatform
+    }
+    
+    func addPlatformIfNeeded() {
+        if platform == nil {
+            let platform = BridgePlatform()
+            platform.navigation = BridgeNavigation()
+            addExport(platform, name: bridgePlatformExportName)
+        }
+    }
+}

--- a/THGBridge/WebViewController.swift
+++ b/THGBridge/WebViewController.swift
@@ -55,7 +55,7 @@ public class WebViewController: UIViewController {
         bridge.platform?.navigation?.webNavigator = self
         
         if isAppearingFromPop {
-            popState()
+            webView.goBack()
             containWebView()
         }
         
@@ -171,7 +171,7 @@ extension WebViewController: UIWebViewDelegate {
 extension WebViewController: WebViewControllerNavigator {
     
     func popState() {
-        webView.goBack()
+        navigationController?.popViewControllerAnimated(shouldAnimateHistoryChange)
     }
     
     func pushState() {

--- a/THGBridge/WebViewController.swift
+++ b/THGBridge/WebViewController.swift
@@ -127,16 +127,11 @@ extension WebViewController: UIWebViewDelegate {
     
     public func webView(webView: UIWebView, shouldStartLoadWithRequest request: NSURLRequest, navigationType: UIWebViewNavigationType) -> Bool {
         
-        var shouldStartLoad = true
-        
-        switch navigationType {
-        case .LinkClicked:
+        if pushesWebViewControllerForNavigationType(navigationType) {
             pushWebViewController(animated: shouldAnimateHistoryChange)
-        default:
-            break
         }
         
-        return shouldStartLoad
+        return true
     }
     
     public func webView(webView: UIWebView, didFailLoadWithError error: NSError) {
@@ -155,6 +150,13 @@ extension WebViewController: UIWebViewDelegate {
         bridge.context = context
         bridge.addPlatformIfNeeded()
         bridge.platform?.navigation?.webNavigator = self
+    }
+    
+    public func pushesWebViewControllerForNavigationType(navigationType: UIWebViewNavigationType) -> Bool {
+        switch navigationType {
+        default:
+            return false
+        }
     }
 }
 

--- a/THGBridge/WebViewController.swift
+++ b/THGBridge/WebViewController.swift
@@ -49,6 +49,7 @@ public class WebViewController: UIViewController {
         
         if isSharingWebView {
             containWebView()
+            webView.scrollView.contentInset = UIEdgeInsetsZero
         }
     }
     
@@ -65,7 +66,6 @@ public class WebViewController: UIViewController {
         webView.delegate = self
         webView.removeFromSuperview()
         webView.frame = view.bounds
-        webView.scrollView.contentInset = UIEdgeInsetsZero
         webView.hidden = false // todo: wait to unhide untill load completes
         view.addSubview(webView)
     }

--- a/THGBridge/WebViewController.swift
+++ b/THGBridge/WebViewController.swift
@@ -1,0 +1,79 @@
+//
+//  WebViewController.swift
+//  THGBridge
+//
+//  Created by Angelo Di Paolo on 4/16/15.
+//  Copyright (c) 2015 TheHolyGrail. All rights reserved.
+//
+
+import Foundation
+
+public class WebViewController: UIViewController {
+    
+    var webView: UIWebView? {
+        didSet {
+            webView?.delegate = self
+        }
+    }
+    
+    private(set) public var url: NSURL?
+    
+    override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: NSBundle?) {
+        super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
+        
+        webView = UIWebView(frame: self.view.frame)
+        webView?.delegate = self
+        view.addSubview(webView!)
+
+    }
+
+    required public init(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    deinit {
+        if webView?.delegate === self {
+            self.webView?.delegate = nil
+        }
+    }
+}
+
+// MARK: - UIViewController
+
+extension WebViewController {
+    
+    override public func viewDidLoad() {
+        super.viewDidLoad()
+    }
+}
+
+// MARK: - Request Loading
+
+extension WebViewController {
+    
+    public func loadURL(url: NSURL) {
+        let request = NSURLRequest(URL: url)
+        self.webView?.loadRequest(request)
+    }
+}
+
+// MARK: - UIWebViewDelegate
+
+extension WebViewController: UIWebViewDelegate {
+    
+    public func webViewDidStartLoad(webView: UIWebView) {
+        
+    }
+    
+    public func webViewDidFinishLoad(webView: UIWebView) {
+        
+    }
+    
+    public func webView(webView: UIWebView, shouldStartLoadWithRequest request: NSURLRequest, navigationType: UIWebViewNavigationType) -> Bool {
+        return true
+    }
+    
+    public func webView(webView: UIWebView, didFailLoadWithError error: NSError) {
+        println("WebViewController Error: \(error)")
+    }
+}

--- a/THGBridgeTests/THGBridgeTests.swift
+++ b/THGBridgeTests/THGBridgeTests.swift
@@ -222,4 +222,11 @@ class THGBridgeTests: XCTestCase {
         
         XCTAssert(bridge.contextValueForName(name).toObject() === export)
     }
+    
+    func testGetWebViewJavaScriptContext() {
+        let webView = UIWebView(frame: CGRectZero)
+        let context = webView.javaScriptContext
+        XCTAssert(context != nil)
+    }
+    
 }


### PR DESCRIPTION
- add web controller that reuses web view between navigation transitions
- integrate web view and bridge with ability to add exports to web view's context
- add pushState/popState bridge methods for explicitly manipulating the navigation stack (no more URL detection BS)
- added web page for testing at http://bridgeofdeath.herokuapp.com/
- test page currently tests pushState/popState methods
