### PR TITLE
NAP-278 - refactor error to use ErrorType

### DIFF
--- a/ELJSBridge/Source/Bridge.swift
+++ b/ELJSBridge/Source/Bridge.swift
@@ -104,18 +104,17 @@ public class Bridge: NSObject {
         }
     }
 
-    private func downloadScript(url: NSURL, completion: (data: NSData?, error: ErrorType?) -> Void)
-    {
-        let downloadTask = NSURLSession.sharedSession().dataTaskWithURL(url) { (data, response, error) -> Void in
-            let httpResponse = response as? NSHTTPURLResponse
-            if httpResponse?.statusCode == 404 {
+    private func downloadScript(url: NSURL, completion: (data: NSData?, error: ErrorType?) -> Void) {
+        let downloadTask = NSURLSession.sharedSession().dataTaskWithURL(url) { data, response, error in
+            if let httpResponse = response as? NSHTTPURLResponse
+                where httpResponse.statusCode == 404 {
                 completion(data: nil, error: ELJSBridgeError.FileDoesNotExist)
             } else {
                 completion(data: data, error: error)
             }
         }
         
-            downloadTask.resume()
+        downloadTask.resume()
     }
 }
 


### PR DESCRIPTION
- Change all `NSError` parameters to `ErrorType`
- Update unit tests to test for `ErrorType` cases instead of `NSError` objects
- Cleanup and simplify unit test logic
